### PR TITLE
Separate token creation and TGE from pool deployment

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -181,12 +181,35 @@ contract Pool is
      * @dev Return if pool had a successful governance TGE
      * @return Is any governance TGE successful
      */
-    function isDAO() external view returns (bool) {
+    function isDAO() public view returns (bool) {
         return
             IToken(tokens[IToken.TokenType.Governance])
                 .isPrimaryTGESuccessful();
     }
-
+    
+    /**
+     * @dev Returns Pool's state.
+     * @return PoolState
+     */
+    function state() public view returns (PoolState) {
+        // Check if Pool is paused
+        if (paused()) {
+            // Return Paused state if true
+            return PoolState.Paused;
+        }
+        // Check if  Pool is Dao
+        if (isDAO()) {
+            // Return Dao state if true
+            return PoolState.Dao;
+        }
+        // Check if Pool has Governance Tokens
+        if (tokens[IToken.TokenType.Governance] != address(0)) {
+            // Return PoolwithToken state if true
+            return PoolState.PoolwithToken;
+        }
+        // Default PoolState
+        return PoolState.Pool;
+    }
     /**
      * @dev Return pool owner
      * @return Owner address

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -72,7 +72,11 @@ contract Pool is
         }
         _;
     }
-
+    
+    modifier onlyState(PoolState state_) {
+        require(state() == state_, ExceptionsLibrary.WRONG_POOL_STATE);
+        _;
+    }
     // INITIALIZER AND CONFIGURATOR
 
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/contracts/Service.sol
+++ b/contracts/Service.sol
@@ -72,10 +72,22 @@ contract Service is
     /**
      * @dev Event emitted on pool creation.
      * @param pool Pool address
-     * @param token Pool token address
-     * @param tge Pool primary TGE address
      */
-    event PoolCreated(address pool, address token, address tge);
+    event PoolCreated(address pool);
+    
+    /**
+     * @dev Event emitted on pool creation.
+     * @param pool Pool address
+     */
+    event TokenCreated(address pool, address token);
+
+    /**
+     * @dev Event emitted on creation of token and primary TGE.
+     * @param pool Pool address
+     * @param tge TGE address
+     * @param token token address
+     */
+    event PrimaryTGECreated(address pool, address tge, address token);
 
     /**
      * @dev Event emitted on creation of secondary TGE.
@@ -120,6 +132,15 @@ contract Service is
         );
         _;
     }
+    
+    modifier onlyPoolState(IPool.PoolState state_) {
+        require(
+            IPool(msg.sender).state() == state_,
+            ExceptionsLibrary.WRONG_POOL_STATE
+        );
+        _;
+    }
+    
 
     // INITIALIZER AND CONSTRUCTOR
 
@@ -172,6 +193,7 @@ contract Service is
     /**
      * @dev Create pool
      * @param pool Pool address. If not address(0) - creates new token and new primary TGE for an existing pool.
+     * @param runPrimaryTGE Determines whether or not to create token and  primary TGE for the pool
      * @param tokenCap Pool token cap
      * @param tokenSymbol Pool token symbol
      * @param tgeInfo Pool TGE parameters
@@ -183,6 +205,7 @@ contract Service is
      */
     function createPool(
         IPool pool,
+        bool runPrimaryTGE,
         uint256 tokenCap,
         string memory tokenSymbol,
         ITGE.TGEInfo memory tgeInfo,
@@ -192,11 +215,7 @@ contract Service is
         string memory trademark,
         string memory metadataURI
     ) external payable nonReentrant whenNotPaused {
-        // Check token cap
-        require(tokenCap >= 1 ether, ExceptionsLibrary.INVALID_CAP);
-
-        // Add protocol fee to token cap
-        tokenCap += getProtocolTokenFee(tokenCap);
+       
 
         if (address(pool) == address(0)) {
             // Check that user is whitelisted and remove him from whitelist
@@ -242,9 +261,37 @@ contract Service is
             // Check that pool is not active yet
             require(!pool.isDAO(), ExceptionsLibrary.IS_DAO);
         }
+        // Emit event
+        emit PoolCreated(address(pool));
+        // Check if the primary TGE should be created
+        if(runPrimaryTGE){
+            createPrimaryTGE( tokenCap,tokenSymbol,tgeInfo, metadataURI);
+        }
+    }
 
+    // PUBLIC INDIRECT FUNCTIONS (CALLED THROUGH POOL)
+
+    /**
+     * @dev Create token and primary TGE
+     * @param tgeInfo TGE parameters
+     * @param metadataURI Metadata URI
+     */
+    function createPrimaryTGE(
+        uint256 tokenCap,
+        string memory tokenSymbol,
+        ITGE.TGEInfo memory tgeInfo,
+        string memory metadataURI
+    ) public override onlyPool onlyPoolState(IPool.PoolState.Pool) nonReentrant whenNotPaused {
+        address pool = msg.sender;
+        // Check token cap
+        require(tokenCap >= 1 ether, ExceptionsLibrary.INVALID_CAP);
+
+        // Add protocol fee to token cap
+        tokenCap += getProtocolTokenFee(tokenCap);
         // Create token contract
         IToken token = _createToken();
+
+        emit TokenCreated(msg.sender, address(token));
 
         // Create TGE contract
         ITGE tge = _createTGE(metadataURI, address(pool));
@@ -264,16 +311,13 @@ contract Service is
         );
 
         // Set token as pool token
-        pool.setToken(address(token), IToken.TokenType.Governance);
+        IPool(msg.sender).setToken(address(token), IToken.TokenType.Governance);
 
         // Initialize TGE
         tge.initialize(token, tgeInfo, protocolTokenFee);
 
-        // Emit event
-        emit PoolCreated(address(pool), address(token), address(tge));
+        emit PrimaryTGECreated(msg.sender, address(tge), address(token));
     }
-
-    // PUBLIC INDIRECT FUNCTIONS (CALLED THROUGH POOL)
 
     /**
      * @dev Create secondary TGE

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -8,6 +8,14 @@ import "./governor/IGovernanceSettings.sol";
 import "./governor/IGovernorProposals.sol";
 
 interface IPool is IGovernorProposals {
+    
+    enum PoolState {
+        Paused,
+        Pool,
+        PoolwithToken,
+        Dao
+    }
+    
     function initialize(
         address owner_,
         string memory trademark_,
@@ -22,6 +30,8 @@ interface IPool is IGovernorProposals {
     function owner() external view returns (address);
 
     function isDAO() external view returns (bool);
+
+    function state() external view returns (PoolState);
 
     function trademark() external view returns (string memory);
 

--- a/contracts/interfaces/IService.sol
+++ b/contracts/interfaces/IService.sol
@@ -16,6 +16,13 @@ interface IService is IAccessControlEnumerableUpgradeable {
 
     function EXECUTOR_ROLE() external view returns (bytes32);
 
+    function createPrimaryTGE(
+        uint256 tokenCap,
+        string memory tokenSymbol,
+        ITGE.TGEInfo memory tgeInfo,
+        string memory metadataURI
+    ) external;
+
     function createSecondaryTGE(
         ITGE.TGEInfo calldata tgeInfo,
         IToken.TokenInfo calldata tokenInfo,

--- a/contracts/libraries/ExceptionsLibrary.sol
+++ b/contracts/libraries/ExceptionsLibrary.sol
@@ -19,6 +19,7 @@ library ExceptionsLibrary {
     string public constant ALREADY_NOT_WHITELISTED = "ALREADY_NOT_WHITELISTED";
     string public constant NOT_SERVICE = "NOT_SERVICE";
     string public constant WRONG_STATE = "WRONG_STATE";
+    string public constant WRONG_POOL_STATE = "WRONG_POOL_STATE";
     string public constant TRANSFER_FAILED = "TRANSFER_FAILED";
     string public constant CLAIM_NOT_AVAILABLE = "CLAIM_NOT_AVAILABLE";
     string public constant NO_LOCKED_BALANCE = "NO_LOCKED_BALANCE";


### PR DESCRIPTION
## Problem:
Currently, the user pays a set-up fee and a pool contract, token contract and tge contract is created for him.

## Solution:
- Make it possible to disable the option to create token and TGE contracts at the same time as the pool client deploys
- Allow clients to deploy these contracts in a separate transaction later

## Additional 
- It is impossible to prevent contracts from breaking due to the inability to calculate a getter for the new state of the pool (purchased, but does not have tokens / TGE)
- It is impossible to re-deploy proxies, only updating implementations is allowed (a feature for a launched product)
- There is a lot of attention paid to the slots occupied
- There are issues when transitioning to existing pool states (some features, states, and getters are very dependent on the current pool state (isDAO()))
- Creating a token and TGE in a separate transaction when they are disabled in a company purchase should not require Governance tokens on the client’s balance

## Implementation:
- Added state() function to Pool contract, returns Pool's state as an enum (pool, dao, paused)
- Created separate function createPrimaryTGE() for token creation and primary TGE
- Removed token creation and primary TGE functionality from createPool() function
- Added boolean runPrimaryTGE to determine if TGE should be run or not
- Restricts createPrimaryTGE() to only be called by the pool contract, and only when the pool state is "Pool"